### PR TITLE
[#2] feat: support workspace configuration

### DIFF
--- a/src/perl.rs
+++ b/src/perl.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use zed_extension_api::{self as zed, LanguageServerId, Result};
+use zed_extension_api::{self as zed, LanguageServerId, settings::LspSettings, Result};
 
 struct PerlExtension {
     cached_binary_path: Option<String>,
@@ -113,6 +113,18 @@ impl zed::Extension for PerlExtension {
             args: vec!["--stdio".to_string()],
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
Fix: #2 

I want to add a path to `@INC` so it adds workspace configuration support

I referred to following https://github.com/baldwindavid/zed/blob/9e14fd915f0c1ce7901e8d4db09afa1020395637/extensions/ruff/src/ruff.rs#L159-L169

This is PerlNavigator options.
https://github.com/bscan/PerlNavigator/blob/de1344a97c883698d5630b01d8299a17a9d95148/package.json#L194

Below is zed's `settings.json` example
This configuration acts as adding `local/lib/perl5` and `lib` to `@INC`
```json
{
  ...
  "lsp": {
    "perlnavigator-server": {
      "settings": {
        "perlnavigator": {
          "includePaths": [
            "local/lib/perl5",
            "lib"
          ]
        }
      }
    }
  }
}
```


