### PR TITLE
ci: auto-open extensions PR on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to Zed Extensions
+
+# Opens a PR against zed-industries/extensions bumping the `perl` submodule and
+# version whenever a version tag is pushed. Tag a release (matching the version
+# in extension.toml) to trigger it, e.g. `git tag v0.4.0 && git push --tags`.
+#
+# Requires a repository secret `COMMITTER_TOKEN`: a personal access token with
+# `repo` and `workflow` scopes, used to push to the fork and open the PR.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    name: Bump zed-industries/extensions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: huacnlee/zed-extension-action@v1
+        with:
+          # Registry id is `perl`, not the repo name (`zed-perl`); must be set
+          # explicitly or the action targets the wrong extension.
+          extension-name: perl
+          push-to: rabbiveesh/extensions
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automates the `zed-industries/extensions` release dance (the manual submodule-bump + PR we've been doing by hand).

## What it does
Uses [`huacnlee/zed-extension-action`](https://github.com/huacnlee/zed-extension-action) (the de-facto standard — catppuccin/zed, metals-zed, etc.). On a pushed `v*` tag it:
1. Clones `zed-industries/extensions`,
2. Bumps the `perl` submodule pointer + `version` in `extensions.toml`,
3. Pushes to the `rabbiveesh/extensions` fork and opens the PR upstream.

## New release flow
1. Merge a version bump into `master` (e.g. the 0.4.0 PR).
2. `git tag v0.4.0 && git push --tags`.
3. The action opens the extensions PR automatically; merge it there to publish.

## ⚠️ Required before this works
Create a repo secret **`COMMITTER_TOKEN`** — a personal access token with `repo` + `workflow` scopes (used to push to the fork and open the PR). Until that secret exists, the workflow will fail on tag pushes. *(This is a manual GitHub step — can't be scripted here.)*

## Notes
- `extension-name` is pinned to `perl` because the registry id differs from the repo name (`zed-perl`); the default would target the wrong entry.
- Independent of #13 — purely additive (one workflow file), no extension code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)